### PR TITLE
修改 ws_conn.go 文件中 read 方法的错误代码

### DIFF
--- a/go_push/gateway/room_manage.go
+++ b/go_push/gateway/room_manage.go
@@ -16,8 +16,8 @@ type RoomManage struct {
 
 func NewRoomManage() {
 	manage = &RoomManage{}
-	return
 }
+
 func GetRoomManage() *RoomManage {
 	return manage
 }

--- a/go_push/gateway/ws_conn.go
+++ b/go_push/gateway/ws_conn.go
@@ -23,8 +23,8 @@ type WsConnection struct {
 }
 
 type WSMessage struct {
-	Type int    `json:"type"`
-	Data string `json:"data"`
+	Type int
+	Data string
 }
 
 var (

--- a/go_push/gateway/ws_conn.go
+++ b/go_push/gateway/ws_conn.go
@@ -1,13 +1,13 @@
 package gateway
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/gorilla/websocket"
-	uuid "github.com/satori/go.uuid"
 	"sync"
 	"time"
+
+	"github.com/gorilla/websocket"
+	uuid "github.com/satori/go.uuid"
 )
 
 type WsConnection struct {
@@ -63,15 +63,16 @@ func (w *WsConnection) read() {
 	w.ws.SetReadLimit(1024)
 	_ = w.ws.SetReadDeadline(time.Now().Add(time.Second * 10))
 	for {
-		if _, Data, err = w.ws.ReadMessage(); err != nil {
+		var messageType int
+		if messageType, Data, err = w.ws.ReadMessage(); err != nil {
 			w.close()
 			return
 		}
-		message := &WSMessage{}
-		if err = json.Unmarshal(Data, message); err != nil {
-			w.close()
-			return
+		message := &WSMessage{
+			Type: messageType,
+			Data: string(Data),
 		}
+
 		select {
 		case w.readChan <- message:
 		case <-w.closeChan:

--- a/go_push/logic/http_handle.go
+++ b/go_push/logic/http_handle.go
@@ -22,7 +22,6 @@ func HttpPushAll(res http.ResponseWriter, req *http.Request) {
 		Info:     val,
 	})
 	_, _ = res.Write([]byte("全部推送任务添加成功"))
-	return
 }
 
 func HttpPushRoom(res http.ResponseWriter, req *http.Request) {
@@ -43,7 +42,6 @@ func HttpPushRoom(res http.ResponseWriter, req *http.Request) {
 		Info:     val,
 	})
 	_, _ = res.Write([]byte(fmt.Sprintf("[%s]房间推送任务添加成功", gateway.RoomTitle[roomId])))
-	return
 }
 
 func HttpRoomJoin(res http.ResponseWriter, req *http.Request) {
@@ -61,7 +59,6 @@ func HttpRoomJoin(res http.ResponseWriter, req *http.Request) {
 		return
 	}
 	_, _ = res.Write([]byte(fmt.Sprintf("加入[%s]房间成功", gateway.RoomTitle[roomId])))
-	return
 }
 
 func HttpRoomLeave(res http.ResponseWriter, req *http.Request) {
@@ -79,5 +76,4 @@ func HttpRoomLeave(res http.ResponseWriter, req *http.Request) {
 		return
 	}
 	_, _ = res.Write([]byte(fmt.Sprintf("离开[%s]房间成功", gateway.RoomTitle[roomId])))
-	return
 }


### PR DESCRIPTION
github.com/gorilla/websocket 包的 conn.Read 方法返回 messageType，不需要 unmarshal Data 到 WSMessage，并且 Unmarshal 会出现错误，修改为直接读取存储即可。