### PR TITLE
perf: replace mutex to RW mutex in LRU

### DIFF
--- a/LRU/list.go
+++ b/LRU/list.go
@@ -10,10 +10,10 @@ type CallBack func(key interface{}, value interface{})
 
 type Lru struct {
 	max   int
-	l     *list.List
+	list  *list.List
 	Call  CallBack
 	cache map[interface{}]*list.Element
-	mu    *sync.Mutex
+	mu    *sync.RWMutex
 }
 
 type Node struct {
@@ -24,32 +24,32 @@ type Node struct {
 func NewLru(len int, c CallBack) *Lru {
 	return &Lru{
 		max:   len,
-		l:     list.New(),
+		list:  list.New(),
 		Call:  c,
 		cache: make(map[interface{}]*list.Element),
-		mu:    new(sync.Mutex),
+		mu:    new(sync.RWMutex),
 	}
 }
 
 func (l *Lru) Add(key interface{}, val interface{}) error {
-	if l.l == nil {
+	if l.list == nil {
 		return errors.New("not init NewLru")
 	}
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	if e, ok := l.cache[key]; ok { //以及存在
 		e.Value.(*Node).Val = val
-		l.l.MoveToFront(e)
+		l.list.MoveToFront(e)
 		return nil
 	}
-	ele := l.l.PushFront(&Node{
+	ele := l.list.PushFront(&Node{
 		Key: key,
 		Val: val,
 	})
 	l.cache[key] = ele
-	if l.max != 0 && l.l.Len() > l.max {
-		if e := l.l.Back(); e != nil {
-			l.l.Remove(e)
+	if l.max != 0 && l.list.Len() > l.max {
+		if e := l.list.Back(); e != nil {
+			l.list.Remove(e)
 			node := e.Value.(*Node)
 			delete(l.cache, node.Key)
 			if l.Call != nil {
@@ -64,18 +64,18 @@ func (l *Lru) Get(key interface{}) (val interface{}, ok bool) {
 	if l.cache == nil {
 		return
 	}
-	l.mu.Lock()
-	defer l.mu.Unlock()
+	l.mu.RLock()
+	defer l.mu.RUnlock()
 	if ele, ok := l.cache[key]; ok {
-		l.l.MoveToFront(ele)
+		l.list.MoveToFront(ele)
 		return ele.Value.(*Node).Val, true
 	}
 	return
 }
 
 func (l *Lru) GetAll() []*Node {
-	l.mu.Lock()
-	defer l.mu.Unlock()
+	l.mu.RLock()
+	defer l.mu.RUnlock()
 	var data []*Node
 	for _, v := range l.cache {
 		data = append(data, v.Value.(*Node))
@@ -91,8 +91,8 @@ func (l *Lru) Del(key interface{}) {
 	defer l.mu.Unlock()
 	if ele, ok := l.cache[key]; ok {
 		delete(l.cache, ele)
-		if e := l.l.Back(); e != nil {
-			l.l.Remove(e)
+		if e := l.list.Back(); e != nil {
+			l.list.Remove(e)
 			delete(l.cache, key)
 			if l.Call != nil {
 				node := e.Value.(*Node)


### PR DESCRIPTION
`Cache` is suitable for **large number of reads**. RWMutex is better than Mutex in this scene.

And `l.l` is a kind of weird name. Maybe we can change it.